### PR TITLE
Fix guitar table of contents

### DIFF
--- a/src/content/guitar/are-you-sleeping.md
+++ b/src/content/guitar/are-you-sleeping.md
@@ -1,7 +1,8 @@
 ---
 title: "Are You Sleeping (Brother John)"
-excerpt: "Frère Jacques"
+excerpt: "Jean-Philippe Rameau"
 classes: wide
+toc: true
 tags:
   - Anya's Favorites
 ---
@@ -76,4 +77,3 @@ G   C  G   C
 </figure>
 
 Chords from [17jita.com](https://www.17jita.com/tab/img/1569.html).
-

--- a/src/content/guitar/the-ants-go-marching.md
+++ b/src/content/guitar/the-ants-go-marching.md
@@ -2,6 +2,7 @@
 title: "🐜 The Ants Go Marching / 🐝 The Bees Go Buzzing"
 excerpt: ""
 classes: wide
+toc: true
 tags:
   - Anya's Favorites
 ---

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -74,7 +74,7 @@ const {
         <AuthorSidebar />
         {showToc && (
           <div class="sticky top-6">
-            <TableOfContents client:visible />
+            <TableOfContents client:load />
           </div>
         )}
       </aside>

--- a/src/pages/guitar/[slug].astro
+++ b/src/pages/guitar/[slug].astro
@@ -33,9 +33,11 @@ const { Content } = await render(post);
       </article>
       <aside class="lg:w-64 shrink-0 space-y-8">
         <AuthorSidebar />
-        <div class="sticky top-6">
-          <TableOfContents client:visible />
-        </div>
+        {post.data.toc && (
+          <div class="sticky top-6">
+            <TableOfContents client:load />
+          </div>
+        )}
       </aside>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enable the TOC on the Are You Sleeping guitar page with frontmatter
- make guitar pages respect the existing toc flag
- hydrate the TOC on page load so it can scan rendered headings

## Test
- npm run build